### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/components/CountryInput.jsx
+++ b/src/components/CountryInput.jsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
-import { Map, Clock, Settings, Pause, Play } from "lucide-react";
+import { useState } from "react";
 
 const CountryInput = ({ onSubmit, disabled }) => {
 	const [inputValue, setInputValue] = useState("");

--- a/src/components/StartOverlay.jsx
+++ b/src/components/StartOverlay.jsx
@@ -1,5 +1,3 @@
-import React, { useState, useEffect, useRef } from "react";
-import { Map, Clock, Settings, Pause, Play } from "lucide-react";
 
 const StartOverlay = ({ onStart, isGameEnded, count }) => {
 	// if (isGameEnded) {


### PR DESCRIPTION
## Summary
- drop unused React hooks and Lucide icons from StartOverlay
- remove unused React hooks and icon imports in CountryInput

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 33 problems, 29 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a12d41a1c88321a00822da3e2f6deb