### PR TITLE
Use hash map for country lookup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Map, Clock, Settings, Pause, Play, RefreshCw } from "lucide-react";
 
 import VALID_COUNTRIES from "./assets/countries_with_continents.json";
@@ -119,15 +119,25 @@ const App = () => {
 		0, 0, 0, 0, 0, 0, 0,
 	]);
 	const [timeLeft, setTimeLeft] = useState(15 * 60); // 15 minutes in seconds
-	const [isGameStarted, setIsGameStarted] = useState(false);
-	const [isGameEnded, setIsGameEnded] = useState(false);
-	const [isMenuDown, setIsMenuDown] = useState(false);
-	const [isGameWon, setIsGameWon] = useState(false);
-	const [isPaused, setIsPaused] = useState(false);
-	const [guessedCountries, setGuessedCountries] = useState(new Set());
-	const [feedback, setFeedback] = useState(null);
-	const [bestScore, setBestScore] = useState(null);
-	const [bestTime, setBestTime] = useState(null);
+        const [isGameStarted, setIsGameStarted] = useState(false);
+        const [isGameEnded, setIsGameEnded] = useState(false);
+        const [isMenuDown, setIsMenuDown] = useState(false);
+        const [isGameWon, setIsGameWon] = useState(false);
+        const [isPaused, setIsPaused] = useState(false);
+        const [guessedCountries, setGuessedCountries] = useState(new Set());
+        const [feedback, setFeedback] = useState(null);
+        const [bestScore, setBestScore] = useState(null);
+        const [bestTime, setBestTime] = useState(null);
+
+        const countryMap = useMemo(() => {
+                const map = {};
+                VALID_COUNTRIES.forEach((c) => {
+                        c.name.forEach((n) => {
+                                map[n.toLowerCase()] = c;
+                        });
+                });
+                return map;
+        }, []);
 
 	useEffect(() => {
 		const storedBestScore = getCookie("bestScore");
@@ -209,11 +219,9 @@ const App = () => {
 		setTimeout(() => setFeedback(null), 3000);
 	};
 
-	const handleCountrySubmit = (country) => {
-		const normalizedCountry = country.trim().toLowerCase();
-		const validCountry = VALID_COUNTRIES.find((c) =>
-			c.name.find((a) => a.toLowerCase() === normalizedCountry)
-		);
+        const handleCountrySubmit = (country) => {
+                const normalizedCountry = country.trim().toLowerCase();
+                const validCountry = countryMap[normalizedCountry];
 
 		if (validCountry) {
 			if (guessedCountries.has(validCountry)) {


### PR DESCRIPTION
## Summary
- Precompute map of country names to data for faster lookups
- Replace array search with O(1) hash map lookup during submissions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous eslint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a12d4724d08321b372728e3d7e941b