### PR TITLE
Show missed countries on game end with replay option

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from "react";
-import { Map, Clock, Settings, Pause, Play, RefreshCw } from "lucide-react";
+import React, { useState, useEffect, useMemo } from "react";
+import { Map, Clock, Settings, Pause, Play } from "lucide-react";
 
 import VALID_COUNTRIES from "./assets/countries_with_continents.json";
 import GameBoard from "./components/GameBoard";
 import StartOverlay from "./components/StartOverlay";
 import CountryInput from "./components/CountryInput";
 import CountryCounter from "./components/CountryCounter";
+import EndGameOverlay from "./components/EndGameOverlay";
 
 function setCookie(name, value, days) {
 	var expires = "";
@@ -45,7 +46,7 @@ const NavBar = () => (
 			</div>
 		</div>
 	</nav>
-);
+	);
 
 const GameTimer = ({ timeLeft }) => (
 	<div className="bg-white p-2 rounded shadow">
@@ -54,7 +55,7 @@ const GameTimer = ({ timeLeft }) => (
 			{(timeLeft % 60).toString().padStart(2, "0")}
 		</p>
 	</div>
-);
+	);
 
 const GiveUpButton = ({ onGiveUp }) => (
 	<button
@@ -63,7 +64,7 @@ const GiveUpButton = ({ onGiveUp }) => (
 	>
 		Give Up
 	</button>
-);
+	);
 
 const PauseButton = ({ isPaused, onTogglePause }) => (
 	<button
@@ -72,19 +73,7 @@ const PauseButton = ({ isPaused, onTogglePause }) => (
 	>
 		{isPaused ? <Play size={24} /> : <Pause size={24} />}
 	</button>
-);
-
-const StartButton = ({ onStart }) => (
-	<button
-		onClick={onStart}
-		className="bg-green-500 hover:bg-green-600 text-white p-2 rounded shadow ml-2"
-	>
-		<div className="flex gap-2">
-			<RefreshCw size={24} />
-			<span className="font-semibold font-montserrat">Retake Quiz</span>
-		</div>
-	</button>
-);
+	);
 
 const FeedbackMessage = ({ message, type }) => (
 	<div
@@ -128,6 +117,12 @@ const App = () => {
 	const [feedback, setFeedback] = useState(null);
 	const [bestScore, setBestScore] = useState(null);
 	const [bestTime, setBestTime] = useState(null);
+
+	const missedCountries = useMemo(
+	() =>
+		VALID_COUNTRIES.filter((country) => !guessedCountries.has(country)),
+		[guessedCountries]
+	);
 
 	useEffect(() => {
 		const storedBestScore = getCookie("bestScore");
@@ -263,9 +258,12 @@ const App = () => {
 						/>
 						<div className="absolute top-4 right-4 flex items-center">
 							<GameTimer timeLeft={timeLeft} />
-							<StartButton onStart={handleStartGame} />
-						</div>
-					</>
+					</div>
+						<EndGameOverlay
+							missedCountries={missedCountries}
+							onPlayAgain={handleStartGame}
+						/>
+				</>
 				)}
 				{isGameStarted && (
 					<>

--- a/src/components/EndGameOverlay.jsx
+++ b/src/components/EndGameOverlay.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+const EndGameOverlay = ({ missedCountries, onPlayAgain }) => {
+	return (
+		<div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
+			<div className="bg-white p-6 rounded-lg max-h-[80vh] w-80 sm:w-96 flex flex-col">
+				<h2 className="text-2xl font-bold mb-4 font-montserrat text-center">
+					Missed Countries ({missedCountries.length})
+				</h2>
+				<div className="flex-1 overflow-y-auto mb-4">
+					<ul className="space-y-1">
+						{missedCountries.map((country) => (
+							<li key={country.alpha2} className="font-montserrat">
+								{country.name[0]}
+							</li>
+						))}
+					</ul>
+				</div>
+				<button
+					onClick={onPlayAgain}
+					className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded w-full font-montserrat"
+				>
+					Play Again
+				</button>
+			</div>
+		</div>
+	);
+};
+
+export default EndGameOverlay;


### PR DESCRIPTION
## Summary
- compute missed countries when the game ends
- display missed countries in a scrollable overlay with play again button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and prop-types errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a12d5032888321b72b78186768eb6f