### PR TITLE
Add configurable game duration with pre-game settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { Map, Clock, Settings, Pause, Play, RefreshCw } from "lucide-react";
+import { useState, useEffect } from "react";
+import { Map, Settings, Pause, Play, RefreshCw } from "lucide-react";
 
 import VALID_COUNTRIES from "./assets/countries_with_continents.json";
 import GameBoard from "./components/GameBoard";
@@ -115,30 +115,36 @@ const BestScoreDisplay = ({ bestScore, bestTime }) => (
 );
 
 const App = () => {
-	const [countriesGuessed, setCountriesGuessed] = useState([
-		0, 0, 0, 0, 0, 0, 0,
-	]);
-	const [timeLeft, setTimeLeft] = useState(15 * 60); // 15 minutes in seconds
+        const [countriesGuessed, setCountriesGuessed] = useState([
+                0, 0, 0, 0, 0, 0, 0,
+        ]);
+        const [gameDuration, setGameDuration] = useState(15 * 60); // default 15 minutes in seconds
+        const [timeLeft, setTimeLeft] = useState(gameDuration);
 	const [isGameStarted, setIsGameStarted] = useState(false);
 	const [isGameEnded, setIsGameEnded] = useState(false);
 	const [isMenuDown, setIsMenuDown] = useState(false);
-	const [isGameWon, setIsGameWon] = useState(false);
 	const [isPaused, setIsPaused] = useState(false);
 	const [guessedCountries, setGuessedCountries] = useState(new Set());
 	const [feedback, setFeedback] = useState(null);
 	const [bestScore, setBestScore] = useState(null);
 	const [bestTime, setBestTime] = useState(null);
 
-	useEffect(() => {
-		const storedBestScore = getCookie("bestScore");
-		const storedBestTime = getCookie("bestTime");
-		if (storedBestScore) {
-			setBestScore(parseInt(storedBestScore));
-		}
-		if (storedBestTime) {
-			setBestTime(parseInt(storedBestTime));
-		}
-	}, []);
+        useEffect(() => {
+                const storedBestScore = getCookie("bestScore");
+                const storedBestTime = getCookie("bestTime");
+                if (storedBestScore) {
+                        setBestScore(parseInt(storedBestScore));
+                }
+                if (storedBestTime) {
+                        setBestTime(parseInt(storedBestTime));
+                }
+        }, []);
+
+        useEffect(() => {
+                if (!isGameStarted) {
+                        setTimeLeft(gameDuration);
+                }
+        }, [gameDuration, isGameStarted]);
 
 	useEffect(() => {
 		let timer;
@@ -155,39 +161,37 @@ const App = () => {
 	}, [isGameStarted, isPaused, timeLeft]);
 
 	useEffect(() => {
-		if (countriesGuessed[0] >= 197) {
-			setIsGameWon(true); // Currently not used for anything
-			setIsGameEnded(true);
-			setIsGameStarted(false);
-			updateBestScore();
-		}
-	}, [countriesGuessed]);
+                if (countriesGuessed[0] >= 197) {
+                        setIsGameEnded(true);
+                        setIsGameStarted(false);
+                        updateBestScore();
+                }
+        }, [countriesGuessed]);
 
-	const updateBestScore = () => {
-		const currentScore = countriesGuessed[0];
-		const currentTime = 15 * 60 - timeLeft; // Time spent in seconds
-		if (
-			!bestScore ||
-			currentScore > bestScore ||
-			(currentScore === bestScore && currentTime < bestTime)
-		) {
-			setBestScore(currentScore);
-			setBestTime(currentTime);
-			setCookie("bestScore", currentScore, 365);
-			setCookie("bestTime", currentTime, 365);
-		}
-	};
+        const updateBestScore = () => {
+                const currentScore = countriesGuessed[0];
+                const currentTime = gameDuration - timeLeft; // Time spent in seconds
+                if (
+                        !bestScore ||
+                        currentScore > bestScore ||
+                        (currentScore === bestScore && currentTime < bestTime)
+                ) {
+                        setBestScore(currentScore);
+                        setBestTime(currentTime);
+                        setCookie("bestScore", currentScore, 365);
+                        setCookie("bestTime", currentTime, 365);
+                }
+        };
 
-	const handleStartGame = () => {
-		setIsGameStarted(true);
-		setIsGameEnded(false);
-		setIsGameWon(false);
-		setTimeLeft(15 * 60); // Reset to 15 minutes
-		setCountriesGuessed([0, 0, 0, 0, 0, 0, 0]);
-		setIsPaused(false);
-		setGuessedCountries(new Set()); // Reset guessed countries
-		setFeedback(null);
-	};
+        const handleStartGame = () => {
+                setIsGameStarted(true);
+                setIsGameEnded(false);
+                setTimeLeft(gameDuration); // Reset to selected duration
+                setCountriesGuessed([0, 0, 0, 0, 0, 0, 0]);
+                setIsPaused(false);
+                setGuessedCountries(new Set()); // Reset guessed countries
+                setFeedback(null);
+        };
 
 	const handleTogglePause = () => {
 		setIsPaused(!isPaused);
@@ -286,13 +290,13 @@ const App = () => {
 						</div>
 					</>
 				)}
-				{!isGameStarted && !isGameEnded && (
-					<StartOverlay
-						onStart={handleStartGame}
-						count={countriesGuessed}
-						isGameEnded={isGameEnded}
-					/>
-				)}
+                                {!isGameStarted && !isGameEnded && (
+                                        <StartOverlay
+                                                onStart={handleStartGame}
+                                                gameDuration={gameDuration}
+                                                onDurationChange={setGameDuration}
+                                        />
+                                )}
 				<CountryInput
 					onSubmit={handleCountrySubmit}
 					disabled={!isGameStarted || isPaused || timeLeft === 0}

--- a/src/components/StartOverlay.jsx
+++ b/src/components/StartOverlay.jsx
@@ -1,36 +1,31 @@
-import React, { useState, useEffect, useRef } from "react";
-import { Map, Clock, Settings, Pause, Play } from "lucide-react";
+const StartOverlay = ({ onStart, gameDuration, onDurationChange }) => {
+        const durations = [5, 10, 15];
 
-const StartOverlay = ({ onStart, isGameEnded, count }) => {
-	// if (isGameEnded) {
-	// 	return (
-	// 		<></>
-	// 		// <div className="absolute rounded-lg inset-0 flex flex-col gap-4 items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
-	// 		// 	<h2 className="text-4xl text-white font-bold text-center">
-	// 		// 		End of Game
-	// 		// 	</h2>
-	// 		// 	<button
-	// 		// 		onClick={onStart}
-	// 		// 		className="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded-lg text-xl transition duration-300 ease-in-out transform hover:scale-105"
-	// 		// 	>
-	// 		// 		Start Game
-	// 		// 	</button>
-	// 		// 	<p className="font-bold text-white">{count}/197 Countries</p>
-	// 		// </div>
-	// 	);
-	// } else
-	{
-		return (
-			<div className="absolute rounded-lg inset-0 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
-				<button
-					onClick={onStart}
-					className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-lg text-xl transition duration-300 ease-in-out transform hover:scale-105 font-montserrat tracking-wide"
-				>
-					Start Game
-				</button>
-			</div>
-		);
-	}
+        return (
+                <div className="absolute rounded-lg inset-0 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
+                        <div className="flex flex-col items-center gap-4">
+                                <label className="text-white font-montserrat">Select Duration:</label>
+                                <select
+                                        value={gameDuration}
+                                        onChange={(e) => onDurationChange(parseInt(e.target.value))}
+                                        className="p-2 rounded"
+                                >
+                                        {durations.map((min) => (
+                                                <option key={min} value={min * 60}>
+                                                        {min} minutes
+                                                </option>
+                                        ))}
+                                </select>
+                                <button
+                                        onClick={onStart}
+                                        className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-lg text-xl transition duration-300 ease-in-out transform hover:scale-105 font-montserrat tracking-wide"
+                                >
+                                        Start Game
+                                </button>
+                        </div>
+                </div>
+        );
 };
 
 export default StartOverlay;
+


### PR DESCRIPTION
## Summary
- allow players to choose a game duration before starting
- replace hard-coded 15 minute timer with selected duration state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 36 problems (32 errors, 4 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a12d565bc083218ab1c7e8c7c603ab