### PR TITLE
Add accessible labels to icon-only buttons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,15 +36,21 @@ const NavBar = () => (
 				Countries of the World
 			</h1>
 			<div className="flex space-x-4">
-				<button className="p-2 hover:bg-blue-700 rounded">
-					<Map size={24} />
-				</button>
-				<button className="p-2 hover:bg-blue-700 rounded">
-					<Settings size={24} />
-				</button>
-			</div>
-		</div>
-	</nav>
+                                <button
+                                        className="p-2 hover:bg-blue-700 rounded"
+                                        aria-label="Map"
+                                >
+                                        <Map size={24} />
+                                </button>
+                                <button
+                                        className="p-2 hover:bg-blue-700 rounded"
+                                        aria-label="Settings"
+                                >
+                                        <Settings size={24} />
+                                </button>
+                        </div>
+                </div>
+        </nav>
 );
 
 const GameTimer = ({ timeLeft }) => (

--- a/src/components/GameBoard.jsx
+++ b/src/components/GameBoard.jsx
@@ -395,20 +395,22 @@ const GameBoard = ({
 					</object>
 				</div>
 				{!isBlurred && (
-					<div className="absolute bottom-4 right-4 space-x-2">
-						<button
-							onClick={handleZoomIn}
-							className="bg-white text-blue-500 px-3 py-1 rounded"
-						>
-							+
-						</button>
-						<button
-							onClick={handleZoomOut}
-							className="bg-white text-blue-500 px-3 py-1 rounded"
-						>
-							-
-						</button>
-					</div>
+                                        <div className="absolute bottom-4 right-4 space-x-2">
+                                                <button
+                                                        onClick={handleZoomIn}
+                                                        className="bg-white text-blue-500 px-3 py-1 rounded"
+                                                        aria-label="Zoom in"
+                                                >
+                                                        +
+                                                </button>
+                                                <button
+                                                        onClick={handleZoomOut}
+                                                        className="bg-white text-blue-500 px-3 py-1 rounded"
+                                                        aria-label="Zoom out"
+                                                >
+                                                        -
+                                                </button>
+                                        </div>
 				)}
 			</div>
 			{isBlurred && (


### PR DESCRIPTION
## Summary
- add aria-label attributes to navigation icon buttons
- label zoom control buttons for screen reader clarity

## Testing
- `npm run lint` *(fails: 50 problems — existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a12d5cae8483219f330064626d4c5d