### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,12 +11,12 @@ import { setItem, getItem } from "./utils/storage";
 import { CONTINENTS, TOTAL_COUNTRIES } from "./constants/continents";
 
 const NavBar = () => (
-	<nav className="bg-blue-600 p-4 text-white">
-		<div className="container mx-auto flex justify-between items-center">
-			<h1 className="text-2xl font-bold font-montserrat tracking-wide">
-				Countries of the World
-			</h1>
-			<div className="flex space-x-4">
+        <nav className="bg-blue-600 p-4 text-white">
+                <div className="container mx-auto flex flex-col sm:flex-row justify-between items-center">
+                        <h1 className="text-xl sm:text-2xl font-bold font-montserrat tracking-wide">
+                                Countries of the World
+                        </h1>
+                        <div className="flex space-x-4 mt-4 sm:mt-0">
                                 <button
                                         className="p-2 hover:bg-blue-700 rounded"
                                         aria-label="Map"
@@ -248,7 +248,7 @@ const App = () => {
 	return (
 		<div className="min-h-screen bg-gray-200">
 			<NavBar />
-			<div className="container mx-auto mt-8 relative">
+<div className="container mx-auto mt-8 relative px-4">
 				<GameBoard
 					isBlurred={isPaused}
 					guessedCountries={guessedCountries}

--- a/src/components/CountryCounter.jsx
+++ b/src/components/CountryCounter.jsx
@@ -3,12 +3,12 @@ import { ChevronRight } from "lucide-react";
 import { CONTINENTS, TOTAL_COUNTRIES } from "../constants/continents";
 
 const CountryCounter = ({ count, isMenuDown, onToggleMenu }) => (
-	<div className="absolute top-4 left-4 bg-white p-2 rounded shadow">
-		<div className="flex gap-2">
-			<p className="pl-1 font-bold tracking-wide text-center text-gray-700 font-montserrat">
+        <div className="absolute top-4 left-4 bg-white p-1 sm:p-2 rounded shadow">
+                <div className="flex gap-2">
+                        <p className="pl-1 font-bold tracking-wide text-center text-gray-700 font-montserrat text-sm sm:text-base">
                                 {count[0]}/{TOTAL_COUNTRIES}
 			</p>
-			<p className="pr-1 tracking-wide text-center text-gray-700 font-montserrat">
+                        <p className="pr-1 tracking-wide text-center text-gray-700 font-montserrat text-sm sm:text-base">
 				Countries
 			</p>
 			<button onClick={onToggleMenu}>

--- a/src/components/CountryInput.jsx
+++ b/src/components/CountryInput.jsx
@@ -11,31 +11,31 @@ const CountryInput = ({ onSubmit, disabled, suggestions = [] }) => {
 		}
 	};
 
-	return (
-		<form onSubmit={handleSubmit} className="mt-4 flex">
-			<input
-                                type="text"
-                                value={inputValue}
-                                onChange={(e) => setInputValue(e.target.value)}
-                                placeholder="Enter a country name"
-                                className="flex-grow p-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-blue-500 font-montserrat"
-                                disabled={disabled}
-                                list="country-suggestions"
-                        />
-                        <datalist id="country-suggestions">
-                                {suggestions.map((name) => (
-                                        <option value={name} key={name} />
-                                ))}
-                        </datalist>
-                        <button
-                                type="submit"
-                                className="bg-blue-500 text-white px-4 py-2 rounded-r-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 font-montserrat"
-                                disabled={disabled}
-			>
-				Submit
-			</button>
-		</form>
-	);
+return (
+<form onSubmit={handleSubmit} className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-0">
+<input
+type="text"
+value={inputValue}
+onChange={(e) => setInputValue(e.target.value)}
+placeholder="Enter a country name"
+className="flex-grow p-2 border border-gray-300 rounded-md sm:rounded-l-md sm:rounded-r-none focus:outline-none focus:ring-2 focus:ring-blue-500 font-montserrat"
+disabled={disabled}
+list="country-suggestions"
+/>
+<datalist id="country-suggestions">
+{suggestions.map((name) => (
+<option value={name} key={name} />
+))}
+</datalist>
+<button
+type="submit"
+className="bg-blue-500 text-white px-4 py-2 rounded-md sm:rounded-l-none sm:rounded-r-md w-full sm:w-auto hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 font-montserrat"
+disabled={disabled}
+>
+Submit
+</button>
+</form>
+);
 };
 
 export default CountryInput;

--- a/src/components/EndGameOverlay.jsx
+++ b/src/components/EndGameOverlay.jsx
@@ -11,8 +11,8 @@ const EndGameOverlay = ({
         const seconds = (timeTaken % 60).toString().padStart(2, "0");
 
         return (
-                <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
-                        <div className="bg-white p-6 rounded-lg max-h-[80vh] w-80 sm:w-96 flex flex-col">
+<div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
+<div className="bg-white p-6 rounded-lg max-h-[80vh] w-11/12 sm:w-96 flex flex-col">
                                 <h2 className="text-2xl font-bold mb-4 font-montserrat text-center">
                                         Game Over
                                 </h2>

--- a/src/components/GameBoard.jsx
+++ b/src/components/GameBoard.jsx
@@ -427,8 +427,8 @@ const GameBoard = ({
 		handleZoom(delta, e.clientX, e.clientY);
 	};
 
-	return (
-		<div className="relative w-full h-full">
+return (
+<div className="relative w-full h-[60vh] sm:h-[70vh]">
 			<div
 				className={`bg-blue-400 p-4 rounded-lg shadow-md relative w-full h-full overflow-hidden select-none transition-opacity duration-500 ${
 					isBlurred ? "opacity-50" : "opacity-100"

--- a/src/components/StartOverlay.jsx
+++ b/src/components/StartOverlay.jsx
@@ -1,9 +1,9 @@
 const StartOverlay = ({ onStart, gameDuration, onDurationChange }) => {
         const durations = [5, 10, 15];
 
-        return (
-                <div className="absolute rounded-lg inset-0 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
-                        <div className="flex flex-col items-center gap-4">
+return (
+<div className="absolute rounded-lg inset-0 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
+<div className="flex flex-col items-center gap-4 w-11/12 max-w-xs">
                                 <label className="text-white font-montserrat">Select Duration:</label>
                                 <select
                                         value={gameDuration}


### PR DESCRIPTION
## Summary
- Make navigation and layout responsive for small screens
- Stack country input and controls vertically on mobile
- Add responsive widths and heights to overlays and map

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: `no-unused-vars`, `react/prop-types`)*

------
https://chatgpt.com/codex/tasks/task_e_68a204b0c7048321bd2747b54e196719