### PR TITLE
docs: document outline quiz mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,52 @@
-# React + Vite
+# Countries Game
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Interactive quiz for learning world countries built with React and Vite.
 
-Currently, two official plugins are available:
+## Getting Started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```bash
+npm install
+npm run dev
+```
+
+## Outline Quiz
+
+The **Outline Quiz** mode challenges you to identify countries using only their borders.
+
+### Gameplay
+
+1. The game displays the silhouette of a random country.
+2. Type the country's name into the answer box.
+3. Submit to check your guess and move to the next outline.
+
+### Development Setup
+
+Generating the outline assets requires a preprocessing step:
+
+```bash
+npm install --save-dev mapshaper @turf/turf
+npm run extract-outlines
+```
+
+`extract-outlines` fetches raw GeoJSON data and produces simplified SVG paths stored in `src/assets/outlines`.
+
+### Switching Modes
+
+The app starts in the classic flag quiz. To switch to the Outline Quiz:
+
+- Launch the dev server: `npm run dev`
+- Use the in-app mode selector to choose **Outline Quiz**, or start directly with:
+
+```bash
+npm run dev -- --mode outline
+```
+
+### Screenshots
+
+![Outline Quiz in action](docs/outline-quiz.gif)
+
+## NPM Scripts & Dependencies
+
+- `extract-outlines` – generates outline assets.
+- Dev dependencies: `mapshaper`, `@turf/turf` for geographic processing.
+


### PR DESCRIPTION
## Summary
- describe Outline Quiz gameplay and setup
- explain how to switch to outline mode
- note script and dependencies for outline extraction

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: missing prop validations)*

------
https://chatgpt.com/codex/tasks/task_e_68a20dc29a2083219646ce1fb719d5e6