### PR TITLE
Display outlines and add home navigation for outline quiz

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -267,7 +267,7 @@ const App = () => {
                         <div className="min-h-screen bg-gray-200">
                                 <NavBar />
                                 <div className="container mx-auto mt-8 relative px-4">
-                                        <OutlineGame />
+                                        <OutlineGame onReturn={() => setGameMode(null)} />
                                 </div>
                         </div>
                 );

--- a/src/components/OutlineGame.test.jsx
+++ b/src/components/OutlineGame.test.jsx
@@ -7,12 +7,20 @@ import App from '../App';
 vi.useFakeTimers();
 
 describe('OutlineGame', () => {
-  it('renders the outline game when starting from the home screen', () => {
+  beforeEach(() => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders an outline and returns home', () => {
     render(<App />);
     fireEvent.click(screen.getByRole('button', { name: /outline quiz/i }));
-    expect(
-      screen.getByPlaceholderText('Enter a country name')
-    ).toBeInTheDocument();
+    expect(screen.getByAltText(/country outline/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /back to home/i }));
+    expect(screen.getByRole('button', { name: /outline quiz/i })).toBeInTheDocument();
   });
 
   it('updates score and timer on a valid guess', () => {
@@ -20,7 +28,7 @@ describe('OutlineGame', () => {
     fireEvent.click(screen.getByRole('button', { name: /outline quiz/i }));
 
     const input = screen.getByPlaceholderText('Enter a country name');
-    fireEvent.change(input, { target: { value: 'France' } });
+    fireEvent.change(input, { target: { value: 'Afghanistan' } });
     fireEvent.click(screen.getByRole('button', { name: /submit/i }));
 
     // Score should increment after a correct guess


### PR DESCRIPTION
## Summary
- Render random country outline in outline quiz mode and track guesses
- Add Back to Home button for navigating out of outline quiz
- Test outline rendering and home navigation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a23f4da260832184d27ced4cedeb14