### PR TITLE
Display end game results next to map and group missed countries

### DIFF
--- a/src/components/EndGameOverlay.jsx
+++ b/src/components/EndGameOverlay.jsx
@@ -1,4 +1,4 @@
-import { TOTAL_COUNTRIES } from "../constants/continents";
+import { TOTAL_COUNTRIES, CONTINENTS } from "../constants/continents";
 
 const EndGameOverlay = ({
 	missedCountries,
@@ -12,43 +12,55 @@ const EndGameOverlay = ({
 	const minutes = Math.floor(timeTaken / 60);
 	const seconds = (timeTaken % 60).toString().padStart(2, "0");
 
-	const capitalizedLabel =
-		itemLabel.charAt(0).toUpperCase() + itemLabel.slice(1);
+        const capitalizedLabel =
+                itemLabel.charAt(0).toUpperCase() + itemLabel.slice(1);
 
-	return (
-		<div className="absolute inset-0 rounded-lg flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
-			<div className="bg-white p-6 rounded-lg max-h-[80vh] w-11/12 sm:w-96 flex flex-col">
-				<h2 className="text-2xl font-bold mb-4 font-montserrat text-center">
-					Game Over
-				</h2>
-				<p className="text-center mb-4 font-montserrat">
-					You guessed {countriesGuessed} of {totalItems} {itemLabel}{" "}
-					in {minutes}:{seconds}
-				</p>
-				<h3 className="text-xl font-bold mb-2 font-montserrat text-center">
-					Missed {capitalizedLabel} ({missedCountries.length})
-				</h3>
-				<div className="flex-1 overflow-y-auto mb-4">
-					<ul className="space-y-1">
-						{missedCountries.map((country) => (
-							<li
-								key={country.alpha2}
-								className="font-montserrat"
-							>
-								{country.name[0]}
-							</li>
-						))}
-					</ul>
-				</div>
-				<button
-					onClick={onPlayAgain}
-					className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded w-full font-montserrat"
-				>
-					{playAgainLabel}
-				</button>
-			</div>
-		</div>
-	);
+        const groupedCountries = CONTINENTS.map((continent, index) => ({
+                name: continent.name,
+                countries: missedCountries.filter(
+                        (country) => country.continent === index + 1
+                ),
+        })).filter((group) => group.countries.length > 0);
+
+        return (
+                <div className="bg-white p-6 rounded-lg max-h-[80vh] w-11/12 sm:w-96 flex flex-col">
+                        <h2 className="text-2xl font-bold mb-4 font-montserrat text-center">
+                                Game Over
+                        </h2>
+                        <p className="text-center mb-4 font-montserrat">
+                                You guessed {countriesGuessed} of {totalItems} {itemLabel}{" "}
+                                in {minutes}:{seconds}
+                        </p>
+                        <h3 className="text-xl font-bold mb-2 font-montserrat text-center">
+                                Missed {capitalizedLabel} ({missedCountries.length})
+                        </h3>
+                        <div className="flex-1 overflow-y-auto mb-4 space-y-4">
+                                {groupedCountries.map((group) => (
+                                        <div key={group.name}>
+                                                <h4 className="font-montserrat font-semibold">
+                                                        {group.name} ({group.countries.length})
+                                                </h4>
+                                                <ul className="space-y-1">
+                                                        {group.countries.map((country) => (
+                                                                <li
+                                                                        key={country.alpha2}
+                                                                        className="font-montserrat"
+                                                                >
+                                                                        {country.name[0]}
+                                                                </li>
+                                                        ))}
+                                                </ul>
+                                        </div>
+                                ))}
+                        </div>
+                        <button
+                                onClick={onPlayAgain}
+                                className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded w-full font-montserrat"
+                        >
+                                {playAgainLabel}
+                        </button>
+                </div>
+        );
 };
 
 export default EndGameOverlay;

--- a/src/components/EndGameOverlay.test.jsx
+++ b/src/components/EndGameOverlay.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import EndGameOverlay from './EndGameOverlay';
+
+const mockCountries = [
+  { alpha2: 'aa', name: ['Aaa'], continent: 1 },
+  { alpha2: 'bb', name: ['Bbb'], continent: 2 },
+];
+
+test('groups missed countries by continent', () => {
+  render(
+    <EndGameOverlay
+      missedCountries={mockCountries}
+      onPlayAgain={() => {}}
+      countriesGuessed={0}
+      timeTaken={0}
+    />
+  );
+  expect(screen.getByText(/North America \(1\)/)).toBeInTheDocument();
+  expect(screen.getByText(/South America \(1\)/)).toBeInTheDocument();
+});

--- a/src/components/OutlineGame.jsx
+++ b/src/components/OutlineGame.jsx
@@ -213,21 +213,45 @@ const OutlineGame = () => {
 				/>
 			)}
 			{hint && <FeedbackMessage message={hint} type="hint" />}
-			{currentCountry && (
-				<div className="flex justify-center my-6">
-					<object
-						data={`/quality_outlines/${
-							QUALITY_OUTLINE_MAP[currentCountry.alpha2]
-						}`}
-						type="image/svg+xml"
-						role="img"
-						aria-label="Country outline"
-						ref={svgObjectRef}
-						onLoad={handleSvgLoad}
-						className="w-96 h-96 drop-shadow-lg"
-					/>
-				</div>
-			)}
+                        {isGameEnded ? (
+                                <div className="flex flex-col md:flex-row justify-center my-6 gap-4">
+                                        {currentCountry && (
+                                                <object
+                                                        data={`/quality_outlines/${
+                                                                QUALITY_OUTLINE_MAP[currentCountry.alpha2]
+                                                        }`}
+                                                        type="image/svg+xml"
+                                                        role="img"
+                                                        aria-label="Country outline"
+                                                        ref={svgObjectRef}
+                                                        onLoad={handleSvgLoad}
+                                                        className="w-96 h-96 drop-shadow-lg"
+                                                />
+                                        )}
+                                        <EndGameOverlay
+                                                missedCountries={missedCountries}
+                                                onPlayAgain={handlePlayAgain}
+                                                countriesGuessed={correct}
+                                                timeTaken={elapsedTime}
+                                        />
+                                </div>
+                        ) : (
+                                currentCountry && (
+                                        <div className="flex justify-center my-6">
+                                                <object
+                                                        data={`/quality_outlines/${
+                                                                QUALITY_OUTLINE_MAP[currentCountry.alpha2]
+                                                        }`}
+                                                        type="image/svg+xml"
+                                                        role="img"
+                                                        aria-label="Country outline"
+                                                        ref={svgObjectRef}
+                                                        onLoad={handleSvgLoad}
+                                                        className="w-96 h-96 drop-shadow-lg"
+                                                />
+                                        </div>
+                                )
+                        )}
 			<div className="font-montserrat mb-4 text-lg">
 				Attempts: {attempts} | Correct: {correct} | Time: {minutes}:
 				{seconds}
@@ -259,14 +283,6 @@ const OutlineGame = () => {
 					suggestions={countryNames}
 				/>
 			</div>
-			{isGameEnded && (
-				<EndGameOverlay
-					missedCountries={missedCountries}
-					onPlayAgain={handlePlayAgain}
-					countriesGuessed={correct}
-					timeTaken={elapsedTime}
-				/>
-			)}
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary
- Show end game panel beside country outline instead of overlaying the entire screen
- Group missed countries by continent in the end game panel
- Test grouping behavior for missed countries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a488836e208321acfbf661c2df77a3