### PR TITLE
feat: show end game summary beside map

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -277,73 +277,84 @@ const App = () => {
 
 	return (
 		<div className="min-h-screen bg-gray-200">
-			<NavBar onSelect={handleSelectGame} />
-			<div className="container mx-auto mt-8 relative px-4">
-				<GameBoard
-					isBlurred={isPaused}
-					guessedCountries={guessedCountries}
-					isGameEnded={isGameEnded}
-					isGameStarted={isGameStarted}
-				/>
-				{isGameEnded && (
-					<>
-						<CountryCounter
-							onToggleMenu={handleToggleMenu}
-							isMenuDown={isMenuDown}
-							count={countriesGuessed}
-						/>
-						<div className="absolute top-4 right-8 flex items-center">
-							<GameTimer timeLeft={timeLeft} />
-						</div>
-						<EndGameOverlay
-							missedCountries={missedCountries}
-							onPlayAgain={handleStartGame}
-							countriesGuessed={countriesGuessed[0]}
-							timeTaken={gameDuration - timeLeft}
-						/>
-					</>
-				)}
-				{isGameStarted && (
-					<>
-						<CountryCounter
-							onToggleMenu={handleToggleMenu}
-							isMenuDown={isMenuDown}
-							count={countriesGuessed}
-						/>
-						<div className="absolute top-4 right-8">
-							<div className="flex items-center">
-								<GameTimer timeLeft={timeLeft} />
-								<PauseButton
-									isPaused={isPaused}
-									onTogglePause={handleTogglePause}
-								/>
-							</div>
-							<GiveUpButton onGiveUp={handleGiveUp} />
-						</div>
-					</>
-				)}
-				{!isGameStarted && !isGameEnded && (
-					<StartOverlay
-						onStart={handleStartGame}
-						gameDuration={gameDuration}
-						onDurationChange={setGameDuration}
-					/>
-				)}
-				<CountryInput
-					onSubmit={handleCountrySubmit}
-					disabled={!isGameStarted || isPaused || timeLeft === 0}
-					suggestions={countryNames}
-				/>
-				{feedback && (
-					<FeedbackMessage
-						message={feedback.message}
-						type={feedback.type}
-					/>
-				)}
-				<BestScoreDisplay bestScore={bestScore} bestTime={bestTime} />
-			</div>
-		</div>
-	);
+                        <NavBar onSelect={handleSelectGame} />
+                        <div className="container mx-auto mt-8 relative px-4">
+                                {isGameEnded ? (
+                                        <div className="flex flex-col lg:flex-row gap-4">
+                                                <div className="relative flex-1">
+                                                        <GameBoard
+                                                                isBlurred={isPaused}
+                                                                guessedCountries={guessedCountries}
+                                                                isGameEnded={isGameEnded}
+                                                                isGameStarted={isGameStarted}
+                                                        />
+                                                        <CountryCounter
+                                                                onToggleMenu={handleToggleMenu}
+                                                                isMenuDown={isMenuDown}
+                                                                count={countriesGuessed}
+                                                        />
+                                                        <div className="absolute top-4 right-8 flex items-center">
+                                                                <GameTimer timeLeft={timeLeft} />
+                                                        </div>
+                                                </div>
+                                                <EndGameOverlay
+                                                        missedCountries={missedCountries}
+                                                        onPlayAgain={handleStartGame}
+                                                        countriesGuessed={countriesGuessed[0]}
+                                                        timeTaken={gameDuration - timeLeft}
+                                                />
+                                        </div>
+                                ) : (
+                                        <>
+                                                <GameBoard
+                                                        isBlurred={isPaused}
+                                                        guessedCountries={guessedCountries}
+                                                        isGameEnded={isGameEnded}
+                                                        isGameStarted={isGameStarted}
+                                                />
+                                                {isGameStarted && (
+                                                        <>
+                                                                <CountryCounter
+                                                                        onToggleMenu={handleToggleMenu}
+                                                                        isMenuDown={isMenuDown}
+                                                                        count={countriesGuessed}
+                                                                />
+                                                                <div className="absolute top-4 right-8">
+                                                                        <div className="flex items-center">
+                                                                                <GameTimer timeLeft={timeLeft} />
+                                                                                <PauseButton
+                                                                                        isPaused={isPaused}
+                                                                                        onTogglePause={handleTogglePause}
+                                                                                />
+                                                                        </div>
+                                                                        <GiveUpButton onGiveUp={handleGiveUp} />
+                                                                </div>
+                                                        </>
+                                                )}
+                                                {!isGameStarted && (
+                                                        <StartOverlay
+                                                                onStart={handleStartGame}
+                                                                gameDuration={gameDuration}
+                                                                onDurationChange={setGameDuration}
+                                                        />
+                                                )}
+                                        </>
+                                )}
+                                <CountryInput
+                                        onSubmit={handleCountrySubmit}
+                                        disabled={!isGameStarted || isPaused || timeLeft === 0}
+                                        suggestions={countryNames}
+                                />
+                                {feedback && (
+                                        <FeedbackMessage
+                                                message={feedback.message}
+                                                type={feedback.type}
+                                        />
+                                )}
+                                <BestScoreDisplay bestScore={bestScore} bestTime={bestTime} />
+                        </div>
+                </div>
+        );
 };
 
 export default App;

--- a/src/components/EndGameOverlay.jsx
+++ b/src/components/EndGameOverlay.jsx
@@ -1,4 +1,4 @@
-import { TOTAL_COUNTRIES } from "../constants/continents";
+import { CONTINENTS, TOTAL_COUNTRIES } from "../constants/continents";
 
 const EndGameOverlay = ({
 	missedCountries,
@@ -12,43 +12,58 @@ const EndGameOverlay = ({
 	const minutes = Math.floor(timeTaken / 60);
 	const seconds = (timeTaken % 60).toString().padStart(2, "0");
 
-	const capitalizedLabel =
-		itemLabel.charAt(0).toUpperCase() + itemLabel.slice(1);
+        const capitalizedLabel =
+                itemLabel.charAt(0).toUpperCase() + itemLabel.slice(1);
 
-	return (
-		<div className="absolute inset-0 rounded-lg flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-md">
-			<div className="bg-white p-6 rounded-lg max-h-[80vh] w-11/12 sm:w-96 flex flex-col">
-				<h2 className="text-2xl font-bold mb-4 font-montserrat text-center">
-					Game Over
-				</h2>
-				<p className="text-center mb-4 font-montserrat">
-					You guessed {countriesGuessed} of {totalItems} {itemLabel}{" "}
-					in {minutes}:{seconds}
-				</p>
-				<h3 className="text-xl font-bold mb-2 font-montserrat text-center">
-					Missed {capitalizedLabel} ({missedCountries.length})
-				</h3>
-				<div className="flex-1 overflow-y-auto mb-4">
-					<ul className="space-y-1">
-						{missedCountries.map((country) => (
-							<li
-								key={country.alpha2}
-								className="font-montserrat"
-							>
-								{country.name[0]}
-							</li>
-						))}
-					</ul>
-				</div>
-				<button
-					onClick={onPlayAgain}
-					className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded w-full font-montserrat"
-				>
-					{playAgainLabel}
-				</button>
-			</div>
-		</div>
-	);
+        const missedByContinent = CONTINENTS.map(() => []);
+        missedCountries.forEach((country) => {
+                const index = country.continent - 1;
+                if (missedByContinent[index]) {
+                        missedByContinent[index].push(country);
+                }
+        });
+
+        return (
+                <div className="bg-white p-6 rounded-lg max-h-[80vh] w-11/12 sm:w-96 flex flex-col">
+                        <h2 className="text-2xl font-bold mb-4 font-montserrat text-center">
+                                Game Over
+                        </h2>
+                        <p className="text-center mb-4 font-montserrat">
+                                You guessed {countriesGuessed} of {totalItems} {itemLabel}{" "}
+                                in {minutes}:{seconds}
+                        </p>
+                        <h3 className="text-xl font-bold mb-2 font-montserrat text-center">
+                                Missed {capitalizedLabel} ({missedCountries.length})
+                        </h3>
+                        <div className="flex-1 overflow-y-auto mb-4">
+                                {missedByContinent.map((countries, idx) => (
+                                        countries.length > 0 && (
+                                                <div key={CONTINENTS[idx].name} className="mb-2">
+                                                        <h4 className="font-semibold font-montserrat">
+                                                                {CONTINENTS[idx].name}
+                                                        </h4>
+                                                        <ul className="ml-4 list-disc">
+                                                                {countries.map((country) => (
+                                                                        <li
+                                                                                key={country.alpha2}
+                                                                                className="font-montserrat"
+                                                                        >
+                                                                                {country.name[0]}
+                                                                        </li>
+                                                                ))}
+                                                        </ul>
+                                                </div>
+                                        )
+                                ))}
+                        </div>
+                        <button
+                                onClick={onPlayAgain}
+                                className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded w-full font-montserrat"
+                        >
+                                {playAgainLabel}
+                        </button>
+                </div>
+        );
 };
 
 export default EndGameOverlay;


### PR DESCRIPTION
## Summary
- Display end-game summary beside the map instead of overlaying it
- Group missed countries by continent in the summary panel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a488836e208321acfbf661c2df77a3