### PR TITLE
Improve mobile map interactions

### DIFF
--- a/src/components/CountryInput.jsx
+++ b/src/components/CountryInput.jsx
@@ -1,15 +1,23 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 const CountryInput = ({ onSubmit, disabled, suggestions = [] }) => {
-	const [inputValue, setInputValue] = useState("");
+        const [inputValue, setInputValue] = useState("");
+        const inputRef = useRef(null);
 
-	const handleSubmit = (e) => {
-		e.preventDefault();
-		if (inputValue.trim()) {
-			onSubmit(inputValue.trim());
-			setInputValue("");
-		}
-	};
+        const handleSubmit = (e) => {
+                e.preventDefault();
+                if (inputValue.trim()) {
+                        onSubmit(inputValue.trim());
+                        setInputValue("");
+                }
+        };
+
+        const handleFocus = () => {
+                const inputEl = inputRef.current;
+                if (inputEl && typeof inputEl.scrollIntoView === "function") {
+                        inputEl.scrollIntoView({ block: "center" });
+                }
+        };
 
 	return (
 		<form
@@ -17,14 +25,16 @@ const CountryInput = ({ onSubmit, disabled, suggestions = [] }) => {
 			className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-0"
 		>
 			<input
-				type="text"
-				value={inputValue}
-				onChange={(e) => setInputValue(e.target.value)}
-				placeholder="Enter a country name"
-				className="flex-grow p-2 border border-gray-300 rounded-md sm:rounded-l-md sm:rounded-r-none focus:outline-none focus:ring-2 focus:ring-blue-500 font-montserrat"
-				disabled={disabled}
-				list="country-suggestions"
-			/>
+                                type="text"
+                                value={inputValue}
+                                onChange={(e) => setInputValue(e.target.value)}
+                                onFocus={handleFocus}
+                                placeholder="Enter a country name"
+                                className="flex-grow p-2 border border-gray-300 rounded-md sm:rounded-l-md sm:rounded-r-none focus:outline-none focus:ring-2 focus:ring-blue-500 font-montserrat"
+                                disabled={disabled}
+                                list="country-suggestions"
+                                ref={inputRef}
+                        />
 			<datalist id="country-suggestions">
 				{suggestions.map((name) => (
 					<option value={name} key={name} />


### PR DESCRIPTION
## Summary
- Keep country input visible on mobile by scrolling into view when focused
- Dynamically size game board to visual viewport height for on-screen keyboards
- Prevent page scrolling during touch pan and pinch gestures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4b68e5ea48321a7467bbf7db14ec2