### PR TITLE
Adjust map height on visual viewport resize

### DIFF
--- a/src/components/GameBoard.jsx
+++ b/src/components/GameBoard.jsx
@@ -15,12 +15,33 @@ const GameBoard = ({
 	const [svgLoaded, setSvgLoaded] = useState(false);
 	const pinchRef = useRef(null);
 
-	const svgObjectRef = useRef(null);
-	const containerRef = useRef(null);
+        const svgObjectRef = useRef(null);
+        const containerRef = useRef(null);
 
-	let highlightedCountries = [...guessedCountries].map(
-		(country) => country.alpha2
-	);
+        let highlightedCountries = [...guessedCountries].map(
+                (country) => country.alpha2
+        );
+
+        useEffect(() => {
+                const visualViewport = window.visualViewport;
+
+                const updateHeight = () => {
+                        if (visualViewport && containerRef.current) {
+                                containerRef.current.style.height = `${visualViewport.height}px`;
+                        }
+                };
+
+                if (visualViewport) {
+                        visualViewport.addEventListener("resize", updateHeight);
+                        updateHeight();
+                }
+
+                return () => {
+                        if (visualViewport) {
+                                visualViewport.removeEventListener("resize", updateHeight);
+                        }
+                };
+        }, []);
 
 	useEffect(() => {
 		const svgObject = svgObjectRef.current;


### PR DESCRIPTION
## Summary
- Dynamically size map container on visual viewport resize

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a50c68ea688321a5b1f9f127970d92