### PR TITLE
Handle mobile viewport changes for inputs and board

### DIFF
--- a/src/components/CountryInput.jsx
+++ b/src/components/CountryInput.jsx
@@ -1,7 +1,17 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 const CountryInput = ({ onSubmit, disabled, suggestions = [] }) => {
-	const [inputValue, setInputValue] = useState("");
+        const [inputValue, setInputValue] = useState("");
+        const inputRef = useRef(null);
+
+        const handleFocus = () => {
+                setTimeout(() => {
+                        inputRef.current?.scrollIntoView({
+                                block: "center",
+                                behavior: "smooth",
+                        });
+                }, 300);
+        };
 
 	const handleSubmit = (e) => {
 		e.preventDefault();
@@ -17,14 +27,16 @@ const CountryInput = ({ onSubmit, disabled, suggestions = [] }) => {
 			className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-0"
 		>
 			<input
-				type="text"
-				value={inputValue}
-				onChange={(e) => setInputValue(e.target.value)}
-				placeholder="Enter a country name"
-				className="flex-grow p-2 border border-gray-300 rounded-md sm:rounded-l-md sm:rounded-r-none focus:outline-none focus:ring-2 focus:ring-blue-500 font-montserrat"
-				disabled={disabled}
-				list="country-suggestions"
-			/>
+                                type="text"
+                                value={inputValue}
+                                onChange={(e) => setInputValue(e.target.value)}
+                                placeholder="Enter a country name"
+                                className="flex-grow p-2 border border-gray-300 rounded-md sm:rounded-l-md sm:rounded-r-none focus:outline-none focus:ring-2 focus:ring-blue-500 font-montserrat"
+                                disabled={disabled}
+                                list="country-suggestions"
+                                ref={inputRef}
+                                onFocus={handleFocus}
+                        />
 			<datalist id="country-suggestions">
 				{suggestions.map((name) => (
 					<option value={name} key={name} />

--- a/src/components/GameBoard.jsx
+++ b/src/components/GameBoard.jsx
@@ -3,24 +3,47 @@ import WorldMap from "../assets/map.svg";
 import VALID_COUNTRIES from "../assets/countries_with_continents.json";
 
 const GameBoard = ({
-	guessedCountries,
-	isBlurred,
-	isGameEnded,
-	isGameStarted,
+        guessedCountries,
+        isBlurred,
+        isGameEnded,
+        isGameStarted,
 }) => {
-	const [zoom, setZoom] = useState(1);
-	const [pan, setPan] = useState({ x: 0, y: 0 });
-	const [isDragging, setIsDragging] = useState(false);
-	const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
-	const [svgLoaded, setSvgLoaded] = useState(false);
-	const pinchRef = useRef(null);
+        const [zoom, setZoom] = useState(1);
+        const [pan, setPan] = useState({ x: 0, y: 0 });
+        const [isDragging, setIsDragging] = useState(false);
+        const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+        const [svgLoaded, setSvgLoaded] = useState(false);
+        const [boardHeight, setBoardHeight] = useState(0);
+        const pinchRef = useRef(null);
 
-	const svgObjectRef = useRef(null);
-	const containerRef = useRef(null);
+        const svgObjectRef = useRef(null);
+        const containerRef = useRef(null);
 
-	let highlightedCountries = [...guessedCountries].map(
-		(country) => country.alpha2
-	);
+        let highlightedCountries = [...guessedCountries].map(
+                (country) => country.alpha2
+        );
+
+        useEffect(() => {
+                const updateHeight = () => {
+                        const height = window.visualViewport
+                                ? window.visualViewport.height
+                                : window.innerHeight;
+                        const ratio = window.innerWidth >= 640 ? 0.7 : 0.6;
+                        setBoardHeight(height * ratio);
+                };
+
+                updateHeight();
+                window.addEventListener("resize", updateHeight);
+                window.visualViewport?.addEventListener("resize", updateHeight);
+
+                return () => {
+                        window.removeEventListener("resize", updateHeight);
+                        window.visualViewport?.removeEventListener(
+                                "resize",
+                                updateHeight
+                        );
+                };
+        }, []);
 
 	useEffect(() => {
 		const svgObject = svgObjectRef.current;
@@ -400,8 +423,8 @@ const GameBoard = ({
 		handleZoom(delta, e.clientX, e.clientY);
 	};
 
-	return (
-		<div className="relative w-full h-[60vh] sm:h-[70vh]">
+        return (
+                <div className="relative w-full" style={{ height: boardHeight }}>
 			<div
 				className={`bg-blue-400 p-4 rounded-lg shadow-md relative w-full h-full overflow-hidden select-none transition-opacity duration-500 ${
 					isBlurred ? "opacity-50" : "opacity-100"


### PR DESCRIPTION
## Summary
- keep country input visible by scrolling it into view on focus
- track visual viewport and resize game board dynamically

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a52e5361ec832182b3c3714f2a9a1b